### PR TITLE
allow word stress symbol for belarussian language, the same as #268

### DIFF
--- a/modules/languages.py
+++ b/modules/languages.py
@@ -25,7 +25,7 @@ language2scripts = {
     'ar': ['Arabic', '[\u064B-\u0655\u0670]'], # 'Arabic', 'Script_Extensions=Arabic,Syriac' Arabic,Syriac frequent at least in Iraq,
     'ast': ['Latin'],
     'az': ['Arabic', 'Cyrillic', 'Latin'],
-    'be': ['Cyrillic'],
+    'be': ['Cyrillic', '[\u0301]'],
     'ber': ['Tifinagh'],
     'bg': ['Cyrillic'],
     'bn': ['Bengali'],


### PR DESCRIPTION
There are about 20000 usage of key name:be:word_stress. All such values have Unicode symbol \u0301 that raises osmose trigger [example](https://osmose.openstreetmap.fr/en/issue/5ff04c7f-77f2-12dc-9832-5d5ee04c36bd)
```
Some characters don't match the language charset
"name:be:word_stress"="Пілаво́йці" unexpected char "́" (COMBINING ACUTE ACCENT, 0x0301)
```

I have made changes to allow such symbol as you did for #268

Could you please accept it.